### PR TITLE
Fixed Date converter unit tests

### DIFF
--- a/src/DevToys.Tools/Helpers/DateHelper.cs
+++ b/src/DevToys.Tools/Helpers/DateHelper.cs
@@ -73,7 +73,10 @@ internal static class DateHelper
     {
         if (value <= 0)
         {
-            return DateTimeOffset.UtcNow;
+            /* Do not use DateTime.UTCNow because it will include nanoseconds,
+             * which we don't support this amount of precision.
+             * The nanoseconds can impact the Ticks. */
+            return DateTime.Today;
         }
 
         if (!DateTime.IsLeapYear(value) && target.Month == 2 && target.Day > 28)

--- a/src/DevToys.Tools/Helpers/DateHelper.cs
+++ b/src/DevToys.Tools/Helpers/DateHelper.cs
@@ -76,7 +76,7 @@ internal static class DateHelper
             /* Do not use DateTime.UTCNow because it will include nanoseconds,
              * which we don't support this amount of precision.
              * The nanoseconds can impact the Ticks. */
-            return DateTime.Today;
+            return DateTime.Today.ToUniversalTime();
         }
 
         if (!DateTime.IsLeapYear(value) && target.Month == 2 && target.Day > 28)

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
@@ -44,7 +44,10 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
     private static readonly SettingDefinition<DateTimeOffset> currentTimeSettings
         = new(
             name: $"{nameof(DateConverterGuiTool)}.{nameof(currentTimeSettings)}",
-            defaultValue: DateTime.UtcNow);
+            /* Do not use DateTime.UTCNow because it will include nanoseconds,
+             * which we don't support this amount of precision.
+             * The nanoseconds can impact the Ticks. */
+            defaultValue: DateTime.Today.ToUniversalTime());
 
     /// <summary>
     /// The timeZone to use.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Date Converter unit tests tend to fail because the expected Ticks is slightly different than the actual one.
After investigation, I found that it's because `currentTimeSettings` defaults to `UTC Now`, which includes nanoseconds.

When we edit the date in the UI, we just alter the year, month, day, hour, second, milliseconds of the time we initially got from `currentTimeSettings`. So we never alter the nanoseconds, making the unit tests failing because the last few digits of the tests may have some nanoseconds different than zero (which are the once we expect in our tests).

This not only impact the unit tests, it also impacts the user, as we display a Tick that includes nanoseconds, which the user can't change (unless he edits the Ticks himself).

## What is the new behavior?

Use `DateTime.Today` converted to UTC, which has nanoseconds set to zero, instead of `DateTime.UTCNow`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux