### PR TITLE
Add handling for unicode escape in JsonYamlConverter

### DIFF
--- a/src/DevToys.Tools.UnitTests/Tools/Converters/JsonYamlConverterCommandLineToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/JsonYamlConverterCommandLineToolTests.cs
@@ -151,6 +151,19 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         consoleOutput.Should().Be("Name: Dor\\u00e9".Replace("\r\n", Environment.NewLine));
     }
 
+    [Fact(DisplayName = "Convert json with not ANSI character should output valid yaml")]
+    public async Task ConvertJsonWithUnicodeEscapeCharacterShouldOutputValidYaml()
+    {
+        _tool.ConversionMode = JsonToYamlConversion.JsonToYaml;
+        _tool.IndentationMode = Indentation.TwoSpaces;
+        _tool.Input = "{\"Name\": \"doré\"}";
+
+        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        result.Should().Be(0);
+        string consoleOutput = _consoleWriter.ToString().Trim();
+        consoleOutput.Should().Be("Name: doré".Replace("\r\n", Environment.NewLine));
+    }
+
     #endregion
 
     #region YamlToJson

--- a/src/DevToys.Tools.UnitTests/Tools/Converters/JsonYamlConverterCommandLineToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/JsonYamlConverterCommandLineToolTests.cs
@@ -138,6 +138,19 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         outputContent.Should().Be("foo: bar\r\nfizz:\r\n    - wizz\r\n".Replace("\r\n", Environment.NewLine));
     }
 
+    [Fact(DisplayName = "Convert json with unicode escape should output valid yaml")]
+    public async Task ConvertJsonWithUnicodeEscapeShouldOutputValidYaml()
+    {
+        _tool.ConversionMode = JsonToYamlConversion.JsonToYaml;
+        _tool.IndentationMode = Indentation.TwoSpaces;
+        _tool.Input = "{\"Name\": \"Dor\\u00e9\"}";
+
+        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        result.Should().Be(0);
+        string consoleOutput = _consoleWriter.ToString().Trim();
+        consoleOutput.Should().Be("Name: Dor\\u00e9".Replace("\r\n", Environment.NewLine));
+    }
+
     #endregion
 
     #region YamlToJson


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

In the feature that converts JSON to YAML, Unicode escapes included in the values are automatically converted.

Issue Number: https://github.com/DevToys-app/DevToys/issues/1112

## What is the new behavior?

In the feature that converts JSON to YAML, Unicode escapes included in the values are automatically converted.
![スクリーンショット 2024-04-28 055034.png](https://github.com/DevToys-app/DevToys.Tools/assets/17356998/9d64f565-2662-48af-bcc1-f1f10d5282d1)


## Other information

 - Unicode escapes are output in lowercase by default.

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux