### PR TITLE
Fixed an issue where progression percentage in Hash Generator goes above 100%

### DIFF
--- a/src/DevToys.Tools/Models/HashingProgress.cs
+++ b/src/DevToys.Tools/Models/HashingProgress.cs
@@ -15,5 +15,5 @@ internal sealed record HashingProgress
 
     internal CancellationToken CancellationToken { get; init; }
 
-    internal double GetPercentage() => 100f * CompletedBytes / TotalBytes;
+    internal double GetPercentage() => Math.Min(100, 100f * CompletedBytes / TotalBytes);
 }


### PR DESCRIPTION


<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Occasionally, Hash Generator progression may goes slightly beyond 100%, making the app crashing.

Logs:
```
2024-06-10T20:06:37.0744619-07:00	Critical	[DevToys.Windows.MainWindow]	[0]	Unhandled exception !!!    (╯°□°）╯︵ ┻━┻
Parameter "percentage" (double) must be between or equal to <0> and <100>, was <100.00000762939453>. (Parameter 'percentage')
Actual value was 100.00000762939453.
System.ArgumentOutOfRangeException: Parameter "percentage" (double) must be between or equal to <0> and <100>, was <100.00000762939453>. (Parameter 'percentage')
Actual value was 100.00000762939453.
   at DevToys.Api.GUI.ProgressAsync[T](T element, Double percentage) in E:\DevToys\src\app\dev\DevToys.Api\Tool\GUI\Components\IUIProgressBar.cs:line 137
   at DevToys.Tools.Tools.Generators.HashAndChecksum.HashAndChecksumGeneratorGuiTool.UpdateProgress(HashingProgress hashingProgress) in E:\DevToys.Tools\src\DevToys.Tools\Tools\Generators\HashAndChecksum\HashAndChecksumGeneratorGuiTool.cs:line 402
   at System.Progress`1.InvokeHandlers(Object state)
   at System.Threading.ExecutionContext.RunForThreadPoolUnsafe[TState](ExecutionContext executionContext, Action`1 callback, TState& state)
   at System.Threading.QueueUserWorkItemCallback`1.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

## What is the new behavior?

Make sure the percentage doesn't go beyond 100%

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [ ] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux