### PR TITLE
Typographical fixes re. Edgar Allan Poe's The Raven in Lorem Ipsum Generator

### DIFF
--- a/src/DevToys.Tools/Assets/Lipsums/theraven.xml
+++ b/src/DevToys.Tools/Assets/Lipsums/theraven.xml
@@ -15,12 +15,12 @@
         ah distinctly i remember it was in the bleak december
         and each separate dying ember wrought its ghost upon the floor
         eagerly i wished the morrow vainly i had sought to borrow
-        from my books surcease of sorrowsorrow for the lost lenore
+        from my books surcease of sorrow sorrow for the lost lenore
         for the rare and radiant maiden whom the angels name lenore
         nameless here for evermore
 
         and the silken sad uncertain rustling of each purple curtain
-        thrilled mefilled me with fantastic terrors never felt before
+        thrilled me filled me with fantastic terrors never felt before
         so that now to still the beating of my heart i stood repeating
         tis some visiter entreating entrance at my chamber door
         some late visiter entreating entrance at my chamber door
@@ -30,7 +30,7 @@
         sir said i or madam truly your forgiveness i implore
         but the fact is i was napping and so gently you came rapping
         and so faintly you came tapping tapping at my chamber door
-        that i scarce was sure i heard youhere i opened wide the door
+        that i scarce was sure i heard you here i opened wide the door
         darkness there and nothing more
 
         deep into that darkness peering long i stood there wondering fearing
@@ -62,7 +62,7 @@
         quoth the raven nevermore
 
         much i marvelled this ungainly fowl to hear discourse so plainly
-        though its answer little meaninglittle relevancy bore
+        though its answer little meaning little relevancy bore
         for we cannot help agreeing that no living human being
         ever yet was blessed with seeing bird above his chamber door
         bird or beast upon the sculptured bust above his chamber door
@@ -80,7 +80,7 @@
         caught from some unhappy master whom unmerciful disaster
         followed fast and followed faster till his songs one burden bore
         till the dirges of his hope that melancholy burden bore
-        of nevernevermore
+        of never nevermore
 
         but the raven still beguiling all my sad soul into smiling
         straight i wheeled a cushioned seat in front of bird and bust and door
@@ -98,20 +98,20 @@
 
         then methought the air grew denser perfumed from an unseen censer
         swung by seraphim whose footfalls tinkled on the tufted floor
-        wretch i cried thy god hath lent theeby these angels he hath sent thee
-        respiterespite and nepenthe from thy memories of lenore
+        wretch i cried thy god hath lent thee by these angels he hath sent thee
+        respite respite and nepenthe from thy memories of lenore
         quaff oh quaff this kind nepenthe and forget this lost lenore
         quoth the raven nevermore
 
-        prophet said i thing of evilprophet still if bird or devil
+        prophet said i thing of evil prophet still if bird or devil
         whether tempter sent or whether tempest tossed thee here ashore
         desolate yet all undaunted on this desert land enchanted
-        on this home by horror hauntedtell me truly i implore
-        is thereis there balm in gileadtell metell me i implore
+        on this home by horror haunted tell me truly i implore
+        is there is there balm in gilead tell me tell me i implore
         quoth the raven nevermore
 
-        prophet said i thing of evilprophet still if bird or devil
-        by that heaven that bends above usby that god we both adore
+        prophet said i thing of evil prophet still if bird or devil
+        by that heaven that bends above us by that god we both adore
         tell this soul with sorrow laden if within the distant aidenn
         it shall clasp a sainted maiden whom the angels name lenore
         clasp a rare and radiant maiden whom the angels name lenore
@@ -120,7 +120,7 @@
         be that our sign of parting bird or fiend i shrieked upstarting
         get thee back into the tempest and the nights plutonian shore
         leave no black plume as a token of that lie thy soul has spoken
-        leave my loneliness unbrokenquit the bust above my door
+        leave my loneliness unbroken quit the bust above my door
         take thy beak from out my heart and take thy form from off my door
         quoth the raven nevermore
 
@@ -129,6 +129,6 @@
         and his eyes have all the seeming of a demons that is dreaming
         and the lamplight oer him streaming throws his shadows on the floor
         and my soul from out that shadow that lies floating on the floor
-        shall be liftednevermore
+        shall be lifted nevermore
     </text>
 </lipsum>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.Designer.cs
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.Designer.cs
@@ -214,7 +214,7 @@ namespace DevToys.Tools.Tools.Generators.LoremIpsum {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Raven (Edward Allen Poe), English.
+        ///   Looks up a localized string similar to The Raven (Edgar Allan Poe), English.
         /// </summary>
         internal static string LipsumTheRaven {
             get {

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.af-ZA.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.af-ZA.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ar-SA.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ar-SA.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.bn-BD.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.bn-BD.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ca-ES.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ca-ES.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.cs-CZ.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.cs-CZ.resx
@@ -169,7 +169,7 @@
     <value>Robinson Crusoe (Daniel Dafoe), esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>Havran (Edward Allen Poe), angličtina</value>
+    <value>Havran (Edgar Allan Poe), angličtina</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), španělština</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.da-DK.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.da-DK.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>Ravnen (Edward Allen Poe), Engelsk</value>
+    <value>Ravnen (Edgar Allan Poe), Engelsk</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tirra og Luna (Federico Garcia Lorca), Spansk</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.de-DE.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.de-DE.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), Englisch</value>
+    <value>The Raven (Edgar Allan Poe), Englisch</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanisch</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.el-GR.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.el-GR.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.en-GB.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.en-GB.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.es-AR.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.es-AR.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.es-ES.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.es-ES.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.fi-FI.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.fi-FI.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.fr-FR.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.fr-FR.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>Le Corbeau (Edward Allen Poe), Anglais</value>
+    <value>Le Corbeau (Edgar Allan Poe), Anglais</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Espagnol</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.he-IL.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.he-IL.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.hi-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.hi-IN.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.hu-HU.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.hu-HU.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.id-ID.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.id-ID.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.it-IT.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.it-IT.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ja-JP.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ja-JP.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.kn-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.kn-IN.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ko-KR.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ko-KR.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.kw-GB.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.kw-GB.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.nb.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.nb.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.nl-NL.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.nl-NL.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.pl-PL.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.pl-PL.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.pt-BR.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.pt-BR.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.pt-PT.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.pt-PT.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ro-RO.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ro-RO.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ru-RU.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ru-RU.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.sr-SP.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.sr-SP.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.sv-SE.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.sv-SE.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ta-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.ta-IN.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.te-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.te-IN.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.tr-TR.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.tr-TR.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.uk-UA.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.uk-UA.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.vi-VN.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.vi-VN.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>

--- a/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.zh-Hant.resx
+++ b/src/DevToys.Tools/Tools/Generators/LoremIpsum/LoremIpsumGenerator.zh-Hant.resx
@@ -169,7 +169,7 @@
     <value>Robinsono Kruso (Daniel Defoe), Esperanto</value>
   </data>
   <data name="LipsumTheRaven" xml:space="preserve">
-    <value>The Raven (Edward Allen Poe), English</value>
+    <value>The Raven (Edgar Allan Poe), English</value>
   </data>
   <data name="LipsumTierrayLuna" xml:space="preserve">
     <value>Tierra y Luna (Federico García Lorca), Spanish</value>


### PR DESCRIPTION
## Pull request type

Other (please describe): User-facing text fixes

## What is the current behavior?

In Lorem Ipsum Generator tool:

* "Edgar Allan Poe" (presumably) misspelled "Edward Allen Poe"
* Missing word breaks in The Raven where em dashes are used in the source material

## What is the new behavior?

Corrected text accordingly

## Quality check

No code was changed