### PR TITLE
ISO 8601 Support In Date Converter

### DIFF
--- a/src/DevToys.Tools.UnitTests/Tools/Converters/DateConverterGuiToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/DateConverterGuiToolTests.cs
@@ -8,6 +8,7 @@ namespace DevToys.Tools.UnitTests.Tools.Converters;
 public class DateConverterGuiToolTests : TestBase
 {
     private const string NumberInputText = "date-converter-number-input";
+    private const string ISO8601StringInputText = "date-converter-iso8601-text-input";
     private const string SelectTimeZoneList = "date-converter-timezone-dropdown";
 
     #region Settings
@@ -41,12 +42,12 @@ public class DateConverterGuiToolTests : TestBase
     #region DateTimeSeconds
 
     [Theory(DisplayName = "Convert valid dateTime with custom epoch and Seconds format should return valid timestamp to Seconds")]
-    [InlineData("1870-01-01T00:00:00.0000000Z", "1870-01-01T00:00:00.0000000Z", "UTC", 0)]
-    [InlineData("1923-11-23T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "UTC", 1700683087)]
-    [InlineData("1800-11-22T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "UTC", -2180836913)]
-    [InlineData("2024-01-01T00:00:00.0000000Z", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4859769600)]
-    [InlineData("1923-11-23T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 1700711887)]
-    [InlineData("2024-11-22T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4888007887)]
+    [InlineData("1870-01-01T00:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", 0)]
+    [InlineData("1923-11-23T19:58:07.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", 1700683087)]
+    [InlineData("1800-11-22T19:58:07.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", -2180836913)]
+    [InlineData("2024-01-01T00:00:00.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4859769600)]
+    [InlineData("1923-11-23T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 1700711887)]
+    [InlineData("2024-11-22T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4888007887)]
     public async Task ConvertValidDateTimeWithCustomEpochAndSecondsFormatShouldReturnValidTimestampInSeconds(
         string dateTimeString,
         string epochString,
@@ -89,16 +90,18 @@ public class DateConverterGuiToolTests : TestBase
         await tool.WorkTask;
 
         GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(date.ToString("O"));
     }
 
     [Theory(DisplayName = "Convert valid dateTime with unix epoch and Seconds format should return valid timestamp to Seconds",
         Skip = "Flaky")]
-    [InlineData("1970-01-01T00:00:00.0000000Z", "UTC", 0)]
-    [InlineData("2023-11-22T19:58:07.0000000Z", "UTC", 1700683087)]
-    [InlineData("1900-11-22T19:58:07.0000000Z", "UTC", -2180836913)]
-    [InlineData("1970-01-01T00:00:00.0000000Z", "Pacific Standard Time", 28800)]
-    [InlineData("2023-11-22T19:58:07.0000000Z", "Pacific Standard Time", 1700711887)]
-    [InlineData("1900-11-22T19:58:07.0000000Z", "Pacific Standard Time", -2180808113)]
+    [InlineData("1970-01-01T00:00:00.0000000+00:00", "UTC", 0)]
+    [InlineData("2023-11-22T19:58:07.0000000+00:00", "UTC", 1700683087)]
+    [InlineData("1900-11-22T19:58:07.0000000+00:00", "UTC", -2180836913)]
+    [InlineData("1970-01-01T00:00:00.0000000-08:00", "Pacific Standard Time", 28800)]
+    [InlineData("2023-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", 1700711887)]
+    [InlineData("1900-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", -2180808113)]
     public async Task ConvertValidDateTimeWithUnixEpochAndSecondsFormatShouldReturnValidTimestampInSeconds(
         string dateTimeString,
         string timeZoneString,
@@ -131,6 +134,8 @@ public class DateConverterGuiToolTests : TestBase
         await tool.WorkTask;
 
         GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(date.ToString("O"));
     }
 
     #endregion
@@ -141,9 +146,9 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData(0, "1870-01-01T00:00:00.0000000Z", "UTC", "1870-01-01T00:00:00.0000000Z")]
     [InlineData(1700683087, "1870-01-01T00:00:00.0000000Z", "UTC", "1923-11-23T19:58:07.0000000Z")]
     [InlineData(-2180836913, "1870-01-01T00:00:00.0000000Z", "UTC", "1800-11-22T19:58:07.0000000Z")]
-    [InlineData(0, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2023-12-31T16:00:00.0000000Z")]
-    [InlineData(1700683087, "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T11:58:07.0000000Z")]
-    [InlineData(-2180836913, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1954-11-22T11:58:07.0000000Z")]
+    [InlineData(0, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2023-12-31T16:00:00.0000000-08:00")]
+    [InlineData(1700683087, "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T11:58:07.0000000-08:00")]
+    [InlineData(-2180836913, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1954-11-22T11:58:07.0000000-08:00")]
     public async Task ConvertValidTimestampWithCustomEpochAndSecondsFormatShouldReturnValidDateTime(
         long timestamp,
         string epochString,
@@ -185,15 +190,17 @@ public class DateConverterGuiToolTests : TestBase
         GetGUIElementById<IUINumberInput>(tool.View, DateHourInputNumber).Text.Should().Be(expectedDate.Hour.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
     }
 
     [Theory(DisplayName = "Convert valid timestamp with unix epoch and Seconds format should return valid dateTime")]
     [InlineData(0, "UTC", "1970-01-01T00:00:00.0000000Z")]
     [InlineData(1700683087, "UTC", "2023-11-22T19:58:07.0000000Z")]
     [InlineData(-2180836913, "UTC", "1900-11-22T19:58:07.0000000Z")]
-    [InlineData(0, "Pacific Standard Time", "1969-12-31T16:00:00.0000000Z")]
-    [InlineData(1700683087, "Pacific Standard Time", "2023-11-22T11:58:07.0000000Z")]
-    [InlineData(-2180836913, "Pacific Standard Time", "1900-11-22T11:58:07.0000000Z")]
+    [InlineData(0, "Pacific Standard Time", "1969-12-31T16:00:00.0000000-08:00")]
+    [InlineData(1700683087, "Pacific Standard Time", "2023-11-22T11:58:07.0000000-08:00")]
+    [InlineData(-2180836913, "Pacific Standard Time", "1900-11-22T11:58:07.0000000-08:00")]
     public async Task ConvertValidTimestampWithUnixEpochAndSecondsFormatShouldReturnValidDateTime(
         long timestamp,
         string timeZoneString,
@@ -226,6 +233,8 @@ public class DateConverterGuiToolTests : TestBase
         GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateMillisecondsInputNumber).Value.Should().Be(0);
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
     }
 
     #endregion
@@ -236,9 +245,9 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData("1870-01-01T00:00:00.0000000Z", "1870-01-01T00:00:00.0000000Z", "UTC", 0)]
     [InlineData("1923-11-23T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "UTC", 1700683087000)]
     [InlineData("1800-11-22T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "UTC", -2180836913000)]
-    [InlineData("2024-01-01T00:00:00.0000000Z", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4859769600000)]
-    [InlineData("1923-11-23T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 1700711887000)]
-    [InlineData("2024-11-22T19:58:07.0000000Z", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4888007887000)]
+    [InlineData("2024-01-01T00:00:00.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4859769600000)]
+    [InlineData("1923-11-23T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 1700711887000)]
+    [InlineData("2024-11-22T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", 4888007887000)]
     public async Task ConvertValidDateTimeWithCustomEpochAndMillisecondsFormatShouldReturnValidTimestampInMilliseconds(
         string dateTimeString,
         string epochString,
@@ -281,6 +290,8 @@ public class DateConverterGuiToolTests : TestBase
         await tool.WorkTask;
 
         GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(date.ToString("O"));
     }
 
     [Theory(DisplayName = "Convert valid dateTime with unix epoch and Milliseconds format should return valid timestamp to Milliseconds",
@@ -288,9 +299,9 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData("1970-01-01T00:00:00.0000000Z", "UTC", 0)]
     [InlineData("2023-11-22T19:58:07.0000000Z", "UTC", 1700683087000)]
     [InlineData("1900-11-22T19:58:07.0000000Z", "UTC", -2180836913000)]
-    [InlineData("1970-01-01T00:00:00.0000000Z", "Pacific Standard Time", 28800000)]
-    [InlineData("2023-11-22T19:58:07.0000000Z", "Pacific Standard Time", 1700711887000)]
-    [InlineData("1900-11-22T19:58:07.0000000Z", "Pacific Standard Time", -2180808113000)]
+    [InlineData("1970-01-01T00:00:00.0000000-08:00", "Pacific Standard Time", 28800000)]
+    [InlineData("2023-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", 1700711887000)]
+    [InlineData("1900-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", -2180808113000)]
     public async Task ConvertValidDateTimeWithUnixEpochAndMillisecondsFormatShouldReturnValidTimestampInMilliseconds(
         string dateTimeString,
         string timeZoneString,
@@ -323,6 +334,8 @@ public class DateConverterGuiToolTests : TestBase
         await tool.WorkTask;
 
         GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(date.ToString("O"));
     }
 
     #endregion
@@ -333,9 +346,9 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData(0, "1870-01-01T00:00:00.0000000Z", "UTC", "1870-01-01T00:00:00.0000000Z")]
     [InlineData(1700683087000, "1870-01-01T00:00:00.0000000Z", "UTC", "1923-11-23T19:58:07.0000000Z")]
     [InlineData(-2180836913000, "1870-01-01T00:00:00.0000000Z", "UTC", "1800-11-22T19:58:07.0000000Z")]
-    [InlineData(0, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2023-12-31T16:00:00.0000000Z")]
-    [InlineData(1700683087000, "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T11:58:07.0000000Z")]
-    [InlineData(-2180836913000, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1954-11-22T11:58:07.0000000Z")]
+    [InlineData(0, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2023-12-31T16:00:00.0000000-08:00")]
+    [InlineData(1700683087000, "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T11:58:07.0000000-08:00")]
+    [InlineData(-2180836913000, "2024-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1954-11-22T11:58:07.0000000-08:00")]
     public async Task ConvertValidTimestampWithCustomEpochAndMillisecondsFormatShouldReturnValidDateTime(
         long timestamp,
         string epochString,
@@ -378,15 +391,17 @@ public class DateConverterGuiToolTests : TestBase
         GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateMillisecondsInputNumber).Text.Should().Be(expectedDate.Millisecond.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
     }
 
     [Theory(DisplayName = "Convert valid timestamp with unix epoch and Milliseconds format should return valid dateTime")]
     [InlineData(0, "UTC", "1970-01-01T00:00:00.0000000Z")]
     [InlineData(1700683087000, "UTC", "2023-11-22T19:58:07.0000000Z")]
     [InlineData(-2180836913000, "UTC", "1900-11-22T19:58:07.0000000Z")]
-    [InlineData(0, "Pacific Standard Time", "1969-12-31T16:00:00.0000000Z")]
-    [InlineData(1700683087000, "Pacific Standard Time", "2023-11-22T11:58:07.0000000Z")]
-    [InlineData(-2180836913000, "Pacific Standard Time", "1900-11-22T11:58:07.0000000Z")]
+    [InlineData(0, "Pacific Standard Time", "1969-12-31T16:00:00.0000000-08:00")]
+    [InlineData(1700683087000, "Pacific Standard Time", "2023-11-22T11:58:07.0000000-08:00")]
+    [InlineData(-2180836913000, "Pacific Standard Time", "1900-11-22T11:58:07.0000000-08:00")]
     public async Task ConvertValidTimestampWithUnixEpochAndMillisecondsFormatShouldReturnValidDateTime(
         long timestamp,
         string timeZoneString,
@@ -419,6 +434,175 @@ public class DateConverterGuiToolTests : TestBase
         GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateMillisecondsInputNumber).Text.Should().Be(expectedDate.Millisecond.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
+    }
+
+    #endregion
+
+    #region ISO8601String
+    [Theory(DisplayName = "Convert valid ISO8601 with custom epoch and Seconds format should return valid DateInputNumber and NumberInputText to Seconds")]
+    [InlineData("1870-01-01T00:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", "1870-01-01T00:00:00.0000000+00:00", 0)]
+    [InlineData("1800-11-22T19:58:07.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", "1800-11-22T19:58:07.0000000+00:00", -2180836913)]
+    [InlineData("2024-01-01T00:00:00.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "UTC", "2024-01-01T08:00:00.0000000+00:00", 4859769600)]
+    [InlineData("1923-11-23T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T19:58:07.0000000-08:00", 1700711887)]
+    [InlineData("2024-01-01T08:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2024-01-01T00:00:00.0000000-08:00", 4859769600)]
+    [InlineData("2024-11-22T19:58:07.0000000+09:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2024-11-22T02:58:07.0000000-08:00", 4887946687)]
+    public async Task ConvertValidISO8601WithCustomEpochAndSecondsFormatShouldReturnValidDateInputNumberAndNumberInputTextToSeconds(
+    string dateTimeString,
+    string epochString,
+        string timeZoneString,
+        string exceptedTimeString,
+        long exceptedTimestamp)
+    {
+        var epoch = DateTimeOffset.Parse(epochString, CultureInfo.InvariantCulture);
+        var expectedDate = DateTimeOffset.Parse(exceptedTimeString, CultureInfo.InvariantCulture);
+
+        DateConverterGuiTool tool = GetToolInstance();
+        IUISwitch epochSettings = GetGUIElementById<IUISwitch>(tool.View, UseCustomEpochSwitch);
+        IUISelectDropDownList timeZoneDropDownList = GetGUIElementById<IUISelectDropDownList>(tool.View, SelectTimeZoneList);
+        IUISetting formatSetting = GetGUIElementById<IUISetting>(tool.View, DateFormatSetting);
+        var formatDropdownList = formatSetting.InteractiveElement as IUISelectDropDownList;
+
+        epochSettings.On();
+
+        int timezoneIndex = Array.FindIndex(timeZoneDropDownList.Items, w => (timeZoneString != "UTC" && w.Text.ToString().Contains(timeZoneString)) || w.Value.Equals(timeZoneString));
+        timeZoneDropDownList.Select(timezoneIndex);
+
+        int formatIndex = Array.FindIndex(formatDropdownList.Items, w => w.Value.Equals(DateFormat.Seconds));
+        formatDropdownList.Select(formatIndex);
+
+        GetGUIElementById<IUINumberInput>(tool.View, EpochYearInputNumber).Text(epoch.Year.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMonthInputNumber).Text(epoch.Month.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochDayInputNumber).Text(epoch.Day.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochHourInputNumber).Text(epoch.Hour.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMinuteInputNumber).Text(epoch.Minute.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochSecondsInputNumber).Text(epoch.Second.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMillisecondsInputNumber).Text(epoch.Millisecond.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text(dateTimeString);
+
+        await tool.WorkTask;
+
+        GetGUIElementById<IUINumberInput>(tool.View, DateYearInputNumber).Text.Should().Be(expectedDate.Year.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMonthInputNumber).Text.Should().Be(expectedDate.Month.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateDayInputNumber).Text.Should().Be(expectedDate.Day.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateHourInputNumber).Text.Should().Be(expectedDate.Hour.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
+
+        GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
+    }
+
+    [Theory(DisplayName = "Convert valid ISO8601 with custom epoch and Milliseconds format should return valid DateInputNumber and NumberInputText to Milliseconds")]
+    [InlineData("1870-01-01T00:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", "1870-01-01T00:00:00.0000000+00:00", 0)]
+    [InlineData("1800-11-22T19:58:07.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", "1800-11-22T19:58:07.0000000+00:00", -2180836913000)]
+    [InlineData("2024-01-01T00:00:00.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "UTC", "2024-01-01T08:00:00.0000000+00:00", 4859769600000)]
+    [InlineData("1923-11-23T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T19:58:07.0000000-08:00", 1700711887000)]
+    [InlineData("2024-01-01T08:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2024-01-01T00:00:00.0000000-08:00", 4859769600000)]
+    [InlineData("2024-11-22T19:58:07.0000000+09:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2024-11-22T02:58:07.0000000-08:00", 4887946687000)]
+    public async Task ConvertValidISO8601WithCustomEpochAndMillisecondsFormatShouldReturnValidDateInputNumberAndNumberInputTextToMilliseconds(
+    string dateTimeString,
+    string epochString,
+        string timeZoneString,
+        string exceptedTimeString,
+        long exceptedTimestamp)
+    {
+        var epoch = DateTimeOffset.Parse(epochString, CultureInfo.InvariantCulture);
+        var expectedDate = DateTimeOffset.Parse(exceptedTimeString, CultureInfo.InvariantCulture);
+
+        DateConverterGuiTool tool = GetToolInstance();
+        IUISwitch epochSettings = GetGUIElementById<IUISwitch>(tool.View, UseCustomEpochSwitch);
+        IUISelectDropDownList timeZoneDropDownList = GetGUIElementById<IUISelectDropDownList>(tool.View, SelectTimeZoneList);
+        IUISetting formatSetting = GetGUIElementById<IUISetting>(tool.View, DateFormatSetting);
+        var formatDropdownList = formatSetting.InteractiveElement as IUISelectDropDownList;
+
+        epochSettings.On();
+
+        int timezoneIndex = Array.FindIndex(timeZoneDropDownList.Items, w => (timeZoneString != "UTC" && w.Text.ToString().Contains(timeZoneString)) || w.Value.Equals(timeZoneString));
+        timeZoneDropDownList.Select(timezoneIndex);
+
+        int formatIndex = Array.FindIndex(formatDropdownList.Items, w => w.Value.Equals(DateFormat.Milliseconds));
+        formatDropdownList.Select(formatIndex);
+
+        GetGUIElementById<IUINumberInput>(tool.View, EpochYearInputNumber).Text(epoch.Year.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMonthInputNumber).Text(epoch.Month.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochDayInputNumber).Text(epoch.Day.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochHourInputNumber).Text(epoch.Hour.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMinuteInputNumber).Text(epoch.Minute.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochSecondsInputNumber).Text(epoch.Second.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMillisecondsInputNumber).Text(epoch.Millisecond.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text(dateTimeString);
+
+        await tool.WorkTask;
+
+        GetGUIElementById<IUINumberInput>(tool.View, DateYearInputNumber).Text.Should().Be(expectedDate.Year.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMonthInputNumber).Text.Should().Be(expectedDate.Month.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateDayInputNumber).Text.Should().Be(expectedDate.Day.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateHourInputNumber).Text.Should().Be(expectedDate.Hour.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMillisecondsInputNumber).Text.Should().Be(expectedDate.Millisecond.ToString());
+
+        GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
+    }
+
+    [Theory(DisplayName = "Convert valid ISO8601 should return valid Ticks")]
+    [InlineData("1870-01-01T00:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", "1870-01-01T00:00:00.0000000+00:00", 589799232000000000)]
+    [InlineData("1800-11-22T19:58:07.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "UTC", "1800-11-22T19:58:07.0000000+00:00", 567990862870000000)]
+    [InlineData("2024-01-01T00:00:00.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "UTC", "2024-01-01T08:00:00.0000000+00:00", 638396928000000000)]
+    [InlineData("1923-11-23T19:58:07.0000000-08:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "1923-11-23T19:58:07.0000000-08:00", 606806350870000000)]
+    [InlineData("2024-01-01T08:00:00.0000000+00:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2024-01-01T00:00:00.0000000-08:00", 638396928000000000)]
+    [InlineData("2024-11-22T19:58:07.0000000+09:00", "1870-01-01T00:00:00.0000000Z", "Pacific Standard Time", "2024-11-22T02:58:07.0000000-08:00", 638678698870000000)]
+    public async Task ConvertValidISO8601ShouldReturnValidTicks(
+    string dateTimeString,
+    string epochString,
+        string timeZoneString,
+        string exceptedTimeString,
+        long exceptedTimestamp)
+    {
+        var epoch = DateTimeOffset.Parse(epochString, CultureInfo.InvariantCulture);
+        var expectedDate = DateTimeOffset.Parse(exceptedTimeString, CultureInfo.InvariantCulture);
+
+        DateConverterGuiTool tool = GetToolInstance();
+        IUISwitch epochSettings = GetGUIElementById<IUISwitch>(tool.View, UseCustomEpochSwitch);
+        IUISelectDropDownList timeZoneDropDownList = GetGUIElementById<IUISelectDropDownList>(tool.View, SelectTimeZoneList);
+        IUISetting formatSetting = GetGUIElementById<IUISetting>(tool.View, DateFormatSetting);
+        var formatDropdownList = formatSetting.InteractiveElement as IUISelectDropDownList;
+
+        epochSettings.On();
+
+        int timezoneIndex = Array.FindIndex(timeZoneDropDownList.Items, w => (timeZoneString != "UTC" && w.Text.ToString().Contains(timeZoneString)) || w.Value.Equals(timeZoneString));
+        timeZoneDropDownList.Select(timezoneIndex);
+
+        int formatIndex = Array.FindIndex(formatDropdownList.Items, w => w.Value.Equals(DateFormat.Ticks));
+        formatDropdownList.Select(formatIndex);
+
+        GetGUIElementById<IUINumberInput>(tool.View, EpochYearInputNumber).Text(epoch.Year.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMonthInputNumber).Text(epoch.Month.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochDayInputNumber).Text(epoch.Day.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochHourInputNumber).Text(epoch.Hour.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMinuteInputNumber).Text(epoch.Minute.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochSecondsInputNumber).Text(epoch.Second.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, EpochMillisecondsInputNumber).Text(epoch.Millisecond.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text(dateTimeString);
+
+        await tool.WorkTask;
+
+        GetGUIElementById<IUINumberInput>(tool.View, DateYearInputNumber).Text.Should().Be(expectedDate.Year.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMonthInputNumber).Text.Should().Be(expectedDate.Month.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateDayInputNumber).Text.Should().Be(expectedDate.Day.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateHourInputNumber).Text.Should().Be(expectedDate.Hour.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
+        GetGUIElementById<IUINumberInput>(tool.View, DateMillisecondsInputNumber).Text.Should().Be(expectedDate.Millisecond.ToString());
+
+        GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTimestamp.ToString());
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
     }
 
     #endregion
@@ -428,9 +612,8 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData("1923-11-23T19:58:07.0000000+00:00", "UTC", 606806062870000000)]
     [InlineData("2024-11-22T19:58:07.0000000+00:00", "UTC", 638679022870000000)]
     [InlineData("2024-01-01T00:00:00.0000000-08:00", "Pacific Standard Time", 638396928000000000)]
-    [InlineData("2024-01-01T00:00:00.0000000+00:00", "Pacific Standard Time", 638396928000000000)]
-    [InlineData("1923-11-23T19:58:07.0000000Z", "Pacific Standard Time", 606806350870000000)]
-    [InlineData("2024-11-22T19:58:07.0000000Z", "Pacific Standard Time", 638679310870000000)]
+    [InlineData("1923-11-23T19:58:07.0000000-08:00", "Pacific Standard Time", 606806350870000000)]
+    [InlineData("2024-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", 638679310870000000)]
     public async Task ConvertValidDateTimeShouldReturnValidTicks(
         string dateTimeString,
         string timeZoneString,
@@ -463,15 +646,16 @@ public class DateConverterGuiToolTests : TestBase
         await tool.WorkTask;
 
         GetGUIElementById<IUINumberInput>(tool.View, NumberInputText).Text.Should().Be(exceptedTicks.ToString());
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(date.ToString("O"));
     }
 
     [Theory(DisplayName = "Convert valid ticks should return valid dateTime")]
     [InlineData(0, "UTC", "0001-01-01T00:00:00.0000000Z")]
     [InlineData(638362798870000000, "UTC", "2023-11-22T19:58:07.0000000Z")]
     [InlineData(599547598870000000, "UTC", "1900-11-22T19:58:07.0000000Z")]
-    [InlineData(0, "Pacific Standard Time", "0001-01-01T00:00:00.0000000Z")]
-    [InlineData(638362798870000000, "Pacific Standard Time", "2023-11-22T11:58:07.0000000Z")]
-    [InlineData(599547598870000000, "Pacific Standard Time", "1900-11-22T11:58:07.0000000Z")]
+    [InlineData(0, "Pacific Standard Time", "0001-01-01T00:00:00.0000000+00:00")]
+    [InlineData(638362798870000000, "Pacific Standard Time", "2023-11-22T11:58:07.0000000-08:00")]
+    [InlineData(599547598870000000, "Pacific Standard Time", "1900-11-22T11:58:07.0000000-08:00")]
     public async Task ConvertValidTicksWithTicksFormatShouldReturnValidDateTime(
         long ticks,
         string timeZoneString,
@@ -504,6 +688,8 @@ public class DateConverterGuiToolTests : TestBase
         GetGUIElementById<IUINumberInput>(tool.View, DateMinuteInputNumber).Text.Should().Be(expectedDate.Minute.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateSecondsInputNumber).Text.Should().Be(expectedDate.Second.ToString());
         GetGUIElementById<IUINumberInput>(tool.View, DateMillisecondsInputNumber).Text.Should().Be(expectedDate.Millisecond.ToString());
+
+        GetGUIElementById<IUISingleLineTextInput>(tool.View, ISO8601StringInputText).Text.Should().Be(expectedDate.ToString("O"));
     }
 
     private static T GetGUIElementById<T>(UIToolView toolView, string name)

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.Designer.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.Designer.cs
@@ -221,7 +221,18 @@ namespace DevToys.Tools.Tools.Converters.Date {
                 return ResourceManager.GetString("InvalidValue", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        /// Looks up a localized string similar to ISO8601 Title.
+        /// </summary>
+        internal static string ISO8601Title
+        {
+            get
+            {
+                return ResourceManager.GetString("ISO8601Title", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Local Date and Time.
         /// </summary>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.af-ZA.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.af-ZA.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ar-SA.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ar-SA.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>الرجاء تحديد مدخل أرقام أو تاريخ</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.bn-BD.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.bn-BD.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ca-ES.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ca-ES.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.cs-CZ.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.cs-CZ.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Zadejte prosím vstupní číslo nebo datum</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.da-DK.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.da-DK.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Angiv inputnummer eller dato</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.de-DE.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.de-DE.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Bitte gib eine Eingabenummer oder ein Datum an</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.el-GR.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.el-GR.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.en-GB.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.en-GB.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.es-AR.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.es-AR.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.es-ES.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.es-ES.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.fi-FI.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.fi-FI.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.fr-FR.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.fr-FR.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Veuillez spécifier un numéro ou une date d'entrée</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.he-IL.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.he-IL.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.hi-IN.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.hi-IN.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.hu-HU.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.hu-HU.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.id-ID.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.id-ID.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.it-IT.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.it-IT.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Specifica un numero o una data</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ja-JP.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ja-JP.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>数値または日付を入力してください</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.kn-IN.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.kn-IN.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ko-KR.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ko-KR.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.kw-GB.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.kw-GB.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.nb.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.nb.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.nl-NL.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.nl-NL.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.pl-PL.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.pl-PL.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.pt-BR.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.pt-BR.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Por favor, especifique um número ou data de entrada</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.pt-PT.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.pt-PT.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ro-RO.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ro-RO.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ru-RU.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ru-RU.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Пожалуйста, укажите номер или дату ввода</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.sr-SP.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.sr-SP.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.sv-SE.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.sv-SE.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ta-IN.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.ta-IN.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.te-IN.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.te-IN.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.tr-TR.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.tr-TR.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Lütfen bir girdi sayısı ya da tarihi belirtin</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.uk-UA.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.uk-UA.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Будь ласка, вкажіть вхідний номер або дату</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.vi-VN.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.vi-VN.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.zh-Hans.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.zh-Hans.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>请输入数字或日期</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverter.zh-Hant.resx
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverter.zh-Hant.resx
@@ -246,4 +246,7 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>Please specify an input number or date</value>
   </data>
+  <data name="ISO8601Title" xml:space="preserve">
+    <value>ISO 8601</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using DevToys.Tools.Helpers;
 using DevToys.Tools.Models;
@@ -407,6 +408,14 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
         }
 
         if (string.IsNullOrEmpty(value))
+        {
+            _errorInfoBar.Description(DateConverter.InvalidValue);
+            _errorInfoBar.Open();
+            return;
+        }
+
+        var timeZoneRegex = new Regex(@"[+-][0-9]{2}:[0-9]{2}|Z$");
+        if (!timeZoneRegex.IsMatch(value))
         {
             _errorInfoBar.Description(DateConverter.InvalidValue);
             _errorInfoBar.Open();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: DevToys-app/DevToys#1229

## What is the new behavior?
![image](https://github.com/DevToys-app/DevToys.Tools/assets/79691301/3a90662b-d32f-454f-a67b-1b4f783afa6f)


<!-- Please describe the behavior or changes that are being added by this PR. -->

- Conversion by ISO 8601 is now possible

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Any format that can be converted with *DateTimeOffset.TryParse* is available.
https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse?view=net-8.0

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux