### PR TITLE
Fixed a bug in date/time conversion when special input is used.

### DIFF
--- a/src/DevToys.Tools/Helpers/DateHelper.cs
+++ b/src/DevToys.Tools/Helpers/DateHelper.cs
@@ -55,18 +55,25 @@ internal static class DateHelper
         DateValueType valueChanged)
     {
         target = TimeZoneInfo.ConvertTime(target, timeZoneInfo);
-        DateTimeOffset result = valueChanged switch
+        try
         {
-            DateValueType.Year => ChangeYear(target, value),
-            DateValueType.Month => target.AddMonths(value - target.Month),
-            DateValueType.Day => target.AddDays(value - target.Day),
-            DateValueType.Hour => target.AddHours(value - target.Hour),
-            DateValueType.Minute => target.AddMinutes(value - target.Minute),
-            DateValueType.Second => target.AddSeconds(value - target.Second),
-            DateValueType.Millisecond => target.AddMilliseconds(value - target.Millisecond),
-            _ => throw new NotImplementedException(),
-        };
-        return new(result, true);
+            DateTimeOffset result = valueChanged switch
+            {
+                DateValueType.Year => ChangeYear(target, value),
+                DateValueType.Month => target.AddMonths(value - target.Month),
+                DateValueType.Day => target.AddDays(value - target.Day),
+                DateValueType.Hour => target.AddHours(value - target.Hour),
+                DateValueType.Minute => target.AddMinutes(value - target.Minute),
+                DateValueType.Second => target.AddSeconds(value - target.Second),
+                DateValueType.Millisecond => target.AddMilliseconds(value - target.Millisecond),
+                _ => throw new NotImplementedException(),
+            };
+            return new(result, true);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return new(target, false);
+        }
     }
 
     private static DateTimeOffset ChangeYear(DateTimeOffset target, int value)

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
@@ -311,9 +311,15 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
 
         TimeZoneInfo timeZoneInfo = GetSelectedTimeZone();
         DateTimeOffset currentTime = _settingsProvider.GetSetting(DateConverterGuiTool.currentTimeSettings);
+        if (!int.TryParse(value, out int parsedValue))
+        {
+            _errorInfoBar.Description(DateConverter.InvalidValue);
+            _errorInfoBar.Open();
+            return;
+        }
 
         ResultInfo<DateTimeOffset> result = DateHelper.ChangeDateTime(
-            Convert.ToInt32(value),
+            parsedValue,
             currentTime,
             timeZoneInfo,
             valueChanged);
@@ -338,8 +344,15 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
 
         DateTimeOffset epochToUse = _settingsProvider.GetSetting(DateConverterGuiTool.customEpochSettings);
 
+        if (!int.TryParse(value, out int parsedValue))
+        {
+            _errorInfoBar.Description(DateConverter.InvalidValue);
+            _errorInfoBar.Open();
+            return;
+        }
+
         ResultInfo<DateTimeOffset> result = DateHelper.ChangeDateTime(
-            Convert.ToInt32(value),
+            parsedValue,
             epochToUse,
             TimeZoneInfo.Utc,
             valueChanged);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Added error handling for special input in date/time conversion.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: DevToys-app/DevToys#1349

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added error handling to DateHelper.cs. If an error occurs, return the original value.
- Change Convert.ToInt32 to int.TryParse and process the error.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Translated by DeepL

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux