### PR TITLE
Add 'Now' Button to the Date Converter

### DIFF
--- a/src/DevToys.Tools/Helpers/DateHelper.cs
+++ b/src/DevToys.Tools/Helpers/DateHelper.cs
@@ -1,4 +1,4 @@
-﻿using DevToys.Tools.Models;
+using DevToys.Tools.Models;
 
 namespace DevToys.Tools.Helpers;
 
@@ -91,5 +91,29 @@ internal static class DateHelper
             target.AddDays(value - target.Day);
         }
         return target.AddYears(value - target.Year);
+    }
+    internal static long GetCurrentDateEpoch(DateFormat format, DateTimeOffset? customEpoch = null,
+        bool usingCustomEpoch = false)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        if (usingCustomEpoch && customEpoch.HasValue)
+        {
+            return format switch
+            {
+                DateFormat.Ticks => (now - customEpoch.Value).Ticks,
+                DateFormat.Seconds => (long)(now - customEpoch.Value).TotalSeconds,
+                DateFormat.Milliseconds => (long)(now - customEpoch.Value).TotalMilliseconds,
+                _ => throw new NotSupportedException("Unsupported format")
+            };
+        }
+
+        return format switch
+        {
+            DateFormat.Ticks => now.Ticks,
+            DateFormat.Seconds => now.ToUnixTimeSeconds(),
+            DateFormat.Milliseconds => now.ToUnixTimeMilliseconds(),
+            _ => throw new NotSupportedException("Unsupported format")
+        };
     }
 }

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using DevToys.Tools.Helpers;
@@ -226,10 +226,33 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
                                 .Step(1)
                                 .Minimum(-2177452704000000)
                                 // Ticks max value
-                                .Maximum(3155861951990000000),
+                                .Maximum(3155861951990000000)
+                                .CommandBarExtraContent(
+                                    Button()
+                                        .Icon("FluentSystemIcons", '\ue243')
+                                        .OnClick(() =>
+                                        {
+                                            _settingsProvider.SetSetting(formatSettings, DateFormat.Seconds);
+                                            _numberInputText.Text(DateHelper
+                                                .GetCurrentDateEpoch(_settingsProvider.GetSetting(formatSettings),
+                                                    _settingsProvider.GetSetting(customEpochSettings),
+                                                    _settingsProvider.GetSetting(useCustomEpochSettings)).ToString());
+                                        })
+                                ),
                             _iso8601FormatTextInput
                                 .Title(DateConverter.ISO8601Title)
-                                .OnTextChanged(OnISOChanged),
+                                .OnTextChanged(OnISOChanged)
+                                .CommandBarExtraContent(Button()
+                                    .Icon("FluentSystemIcons", '\ue243')
+                                    .OnClick(() =>
+                                    {
+                                        _settingsProvider.SetSetting(formatSettings, DateFormat.Seconds);
+                                        _numberInputText.Text(DateHelper
+                                            .GetCurrentDateEpoch(_settingsProvider.GetSetting(formatSettings),
+                                                _settingsProvider.GetSetting(customEpochSettings),
+                                                _settingsProvider.GetSetting(useCustomEpochSettings))
+                                            .ToString());
+                                    })),
                             DateTimeStack()
                         )
                 )

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
@@ -232,7 +232,6 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
                                         .Icon("FluentSystemIcons", '\ue243')
                                         .OnClick(() =>
                                         {
-                                            _settingsProvider.SetSetting(formatSettings, DateFormat.Seconds);
                                             _numberInputText.Text(DateHelper
                                                 .GetCurrentDateEpoch(_settingsProvider.GetSetting(formatSettings),
                                                     _settingsProvider.GetSetting(customEpochSettings),
@@ -246,7 +245,6 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
                                     .Icon("FluentSystemIcons", '\ue243')
                                     .OnClick(() =>
                                     {
-                                        _settingsProvider.SetSetting(formatSettings, DateFormat.Seconds);
                                         _numberInputText.Text(DateHelper
                                             .GetCurrentDateEpoch(_settingsProvider.GetSetting(formatSettings),
                                                 _settingsProvider.GetSetting(customEpochSettings),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
N/A

Issue Number: [Issue on DevToys Repository - 1358](https://github.com/DevToys-app/DevToys/issues/1358)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a GetCurrentDateEpoch function that takes user settings (format, customEpoch, usingCustomEpoch) and returns date according to those params
- Adds button using CommandBarExtraContent on ISO 8601 input and "Date" input
- Directly sets the "Date" box to the response from GetCurrentDateEpoch using OnClick Handle, ISO also updates to that value automatically 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

| Before | After|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ac3f61dd-2cd7-4754-be0a-6c070a4bac7e)| ![ScreenRecording2024-09-21174629-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/5813da51-0873-48eb-bbad-8c0f9f863796)| 


## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux