### PR TITLE
Allow UTF-16 surrogate pairs in Base64 decoded strings

### DIFF
--- a/src/DevToys.Tools.UnitTests/Tools/Helpers/Base64HelperTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Helpers/Base64HelperTests.cs
@@ -13,6 +13,7 @@ public class Base64HelperTests
     [InlineData("aGVsbG8gd2f9ybGQ=", false)]
     [InlineData("SGVsbG8gV29y", true)]
     [InlineData("SGVsbG8gVa29y", false)]
+    [InlineData("aGVsbG8gd29ybGQg8J+Xne+4jwo=", true)]
     public void IsValid(string input, bool expectedResult)
     {
         Base64Helper.IsBase64DataStrict(input).Should().Be(expectedResult);

--- a/src/DevToys.Tools/Helpers/Base64Helper.cs
+++ b/src/DevToys.Tools/Helpers/Base64Helper.cs
@@ -59,7 +59,8 @@ internal static partial class Base64Helper
             if (!(current == 0x9
                 || current == 0xA
                 || current == 0xD
-                || current >= 0x20 && current <= 0xD7FF
+                || current >= 0x20 && current <= 0xDBFF
+                || current >= 0xDC00 && current <= 0xDFFF
                 || current >= 0xE000 && current <= 0xFFFD
                 || current >= 0x10000 && current <= 0x10FFFF))
             {


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Base64 decoding fails with "<Invalid Base64>" when UTF-16 surrogate pairs are encountered.  Surrogate pairs allow the Unicode encoding to encode characters with codepoints greater than 0xFFFF in UTF-16.  In the linked issue the the example document includes the key emoji (🗝️) which is represented in UTF-16 as `\ud83d\udddd`.

Issue Number: https://github.com/DevToys-app/DevToys/issues/1461

## What is the new behavior?

- Expand the allowed character ranges to include the UTF-16 surrogate pair ranges 
  - U+D800—U+DBFF (high surrogates)
  - U+DC00—U+DFFF (low surrogates)

## Other information

[Unicode documentation for UTF-16 surrogate pairs](https://unicodebook.readthedocs.io/unicode_encodings.html#utf-16-surrogate-pairs)

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux