### PR TITLE
Remove last empty line from password and UUID generator

### DIFF
--- a/src/DevToys.Tools/Tools/Generators/Password/PasswordGeneratorGuidTool.cs
+++ b/src/DevToys.Tools/Tools/Generators/Password/PasswordGeneratorGuidTool.cs
@@ -281,7 +281,10 @@ internal sealed class PasswordGeneratorGuidTool : IGuiTool
 
         // Generate a random password using the the combined character set.
         var newPasswords = new StringBuilder();
-        for (int i = 0; i < _settingsProvider.GetSetting(passwordsToGenerate); i++)
+
+        int passwordsCount = _settingsProvider.GetSetting(passwordsToGenerate);
+
+        for (int i = 0; i < passwordsCount; i++)
         {
             string password
                 = PasswordGeneratorHelper.GeneratePassword(
@@ -292,9 +295,18 @@ internal sealed class PasswordGeneratorGuidTool : IGuiTool
                     hasSpecialCharacters,
                     excludedCharactersList);
 
-            if (password.Length > 0)
+            if (password.Length == 0)
+            {
+                continue;
+            }
+
+            if (i != passwordsCount - 1)
             {
                 newPasswords.AppendLine(password);
+            }
+            else
+            {
+                newPasswords.Append(password);
             }
         }
 

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGeneratorGuidTool.cs
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGeneratorGuidTool.cs
@@ -184,7 +184,9 @@ internal sealed class UUIDGeneratorGuidTool : IGuiTool
     {
         var newGuids = new StringBuilder();
 
-        for (int i = 0; i < Math.Max(_settingsProvider.GetSetting(uuidToGenerate), 1); i++)
+        int guidsCount = Math.Max(_settingsProvider.GetSetting(uuidToGenerate), 1);
+
+        for (int i = 0; i < guidsCount; i++)
         {
             string newUuid
                 = UuidHelper.GenerateUuid(
@@ -192,7 +194,14 @@ internal sealed class UUIDGeneratorGuidTool : IGuiTool
                     _settingsProvider.GetSetting(hyphens),
                     _settingsProvider.GetSetting(uppercase));
 
-            newGuids.AppendLine(newUuid);
+            if (i != guidsCount - 1)
+            {
+                newGuids.AppendLine(newUuid);
+            }
+            else
+            {
+                newGuids.Append(newUuid);
+            }
         }
 
         _outputText.Text(newGuids.ToString());


### PR DESCRIPTION
When using the UUID or password generator, an empty line is added after the generated values. This is annoying because when you copy the output, you have to press backspace to remove the extra line.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

When using the UUID or password generator, an empty line is added after the generated values.

Issue Number: #1501

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Remove the last empty line

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux