### PR TITLE
add multiline option to base 64 text encode/decode

### DIFF
--- a/src/DevToys.Tools.UnitTests/Tools/EncodersDecoders/Base64Text/Base64TextEncoderDecoderGuiToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/EncodersDecoders/Base64Text/Base64TextEncoderDecoderGuiToolTests.cs
@@ -22,9 +22,9 @@ public sealed class Base64TextEncoderDecoderGuiToolTests : TestBase
     [Fact]
     public async Task EncodeUtf8()
     {
-        _inputBox.Text("Hello world &é'(-è_çèà)");
+        _inputBox.Text($"Hello world &é'(-è_çèà){Environment.NewLine}Hello world &é'(-è_çèà)");
         await _tool.WorkTask;
-        _outputBox.Text.Should().Be("SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ==");
+        _outputBox.Text.Should().Be("SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ0KSGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ==");
     }
 
     [Fact]
@@ -33,9 +33,9 @@ public sealed class Base64TextEncoderDecoderGuiToolTests : TestBase
         var encodingOption = (IUISelectDropDownList)((IUISetting)_toolView.GetChildElementById("base64-text-encoding-setting")).InteractiveElement;
         encodingOption.Select(1); // Select ASCII
 
-        _inputBox.Text("Hello world &é'(-è_çèà)");
+        _inputBox.Text($"Hello world &é'(-è_çèà){Environment.NewLine}Hello world &é'(-è_çèà)");
         await _tool.WorkTask;
-        _outputBox.Text.Should().Be("SGVsbG8gd29ybGQgJj8nKC0/Xz8/Pyk=");
+        _outputBox.Text.Should().Be("SGVsbG8gd29ybGQgJj8nKC0/Xz8/PykNCkhlbGxvIHdvcmxkICY/JygtP18/Pz8p");
     }
 
     [Fact]
@@ -48,12 +48,32 @@ public sealed class Base64TextEncoderDecoderGuiToolTests : TestBase
         conversionMode.Off(); // Switch to Decode
 
         await _tool.WorkTask;
-        _inputBox.Text.Should().Be("SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ==");
+        _inputBox.Text.Should().Be("SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ0KSGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ==");
         await _tool.WorkTask;
         _outputBox.Text("Hello world &é'(-è_çèà)");
 
         conversionMode.On(); // Switch to Encode
         await _tool.WorkTask;
+        await EncodeUtf8();
+    }
+
+    [Fact]
+    public async Task SwitchMultilineMode()
+    {
+        var multilineMode = (IUISwitch)_toolView.GetChildElementById("base64-text-multiline-mode-switch");
+
+        await EncodeUtf8();
+
+        multilineMode.On();
+
+        await _tool.WorkTask;
+        _outputBox.Text.Should().Be($"SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ=={Environment.NewLine}SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ==");
+        await _tool.WorkTask;
+
+        multilineMode.Off();
+        await _tool.WorkTask;
+        _outputBox.Text.Should().Be("SGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ0KSGVsbG8gd29ybGQgJsOpJygtw6hfw6fDqMOgKQ==");
+
         await EncodeUtf8();
     }
 }

--- a/src/DevToys.Tools/Tools/EncodersDecoders/Base64Text/Base64TextEncoderDecoder.Designer.cs
+++ b/src/DevToys.Tools/Tools/EncodersDecoders/Base64Text/Base64TextEncoderDecoder.Designer.cs
@@ -113,6 +113,24 @@ namespace DevToys.Tools.Tools.EncodersDecoders.Base64Text {
                 return ResourceManager.GetString("ConversionEncode", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to MultilineTitle.
+        /// </summary>
+        internal static string MultilineTitle {
+            get {
+                return ResourceManager.GetString("MultilineTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to MultilineOptionDescription.
+        /// </summary>
+        internal static string MultilineOptionDescription {
+            get {
+                return ResourceManager.GetString("MultilineOptionDescription", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Whether to encode or decode Base64 text.

--- a/src/DevToys.Tools/Tools/EncodersDecoders/Base64Text/Base64TextEncoderDecoder.resx
+++ b/src/DevToys.Tools/Tools/EncodersDecoders/Base64Text/Base64TextEncoderDecoder.resx
@@ -187,4 +187,10 @@
   <data name="Utf8" xml:space="preserve">
     <value>UTF-8</value>
   </data>
+  <data name="MultilineTitle" xml:space="preserve">
+    <value>Multiline</value>
+  </data>
+  <data name="MultilineOptionDescription" xml:space="preserve">
+    <value>Whether to encode / decode each line separately</value>
+  </data>
 </root>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

The current behavior of Base64Text Encode/Decode only encodes/decodes the entire text block

Issue Number: N/A

## What is the new behavior?

- Option to allow user to encode/decode on a per line basis.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Functionality Demo:
![2025-02-22_11-26-15](https://github.com/user-attachments/assets/425d6aaa-a8f5-493c-9698-1eeb4d9e2319)

Tests:
![image](https://github.com/user-attachments/assets/734af200-3a34-4249-8394-fb4dca059552)


## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux