### PR TITLE
added: option to generate a mongodb ObjectId.

### DIFF
--- a/src/DevToys.Tools/Models/UuidVersion.cs
+++ b/src/DevToys.Tools/Models/UuidVersion.cs
@@ -4,5 +4,6 @@ internal enum UuidVersion
 {
     One,
     Four,
-    Seven
+    Seven,
+    ObjectId
 }

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.Designer.cs
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.Designer.cs
@@ -224,6 +224,17 @@ namespace DevToys.Tools.Tools.Generators.UUID {
         }
 
         /// <summary>
+        /// Looks up a localized string for UuidObjectId
+        /// </summary>
+        internal static string UuidObjectId
+        {
+            get
+            {
+                return ResourceManager.GetString("UuidObjectId", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Choose the version of UUID to generate.
         /// </summary>
         internal static string VersionDescription {

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.af-ZA.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.af-ZA.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ar-SA.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ar-SA.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.be-BY.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.be-BY.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.bn-BD.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.bn-BD.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ca-ES.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ca-ES.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Actualitza</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.cs-CZ.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.cs-CZ.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Obnovit</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.da-DK.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.da-DK.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Opdatér</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.de-DE.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.de-DE.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Aktualisieren</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.el-GR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.el-GR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.en-GB.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.en-GB.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.es-AR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.es-AR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.es-ES.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.es-ES.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Actualizar</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.fa-IR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.fa-IR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.fi-FI.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.fi-FI.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.fr-FR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.fr-FR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Rafraîchir</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.he-IL.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.he-IL.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.hi-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.hi-IN.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.hu-HU.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.hu-HU.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.id-ID.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.id-ID.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Perbarui</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.is-IS.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.is-IS.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.it-IT.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.it-IT.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ja-JP.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ja-JP.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>再生成</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ka-GE.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ka-GE.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.kn-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.kn-IN.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ko-KR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ko-KR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.kw-GB.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.kw-GB.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.nb.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.nb.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.nl-NL.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.nl-NL.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.pl-PL.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.pl-PL.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.pt-BR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.pt-BR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Atualizar</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.pt-PT.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.pt-PT.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ro-RO.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ro-RO.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ru-RU.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ru-RU.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Обновить</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.sv-SE.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.sv-SE.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ta-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.ta-IN.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.te-IN.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.te-IN.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.tr-TR.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.tr-TR.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Yenile</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.uk-UA.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.uk-UA.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.vi-VN.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.vi-VN.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.zh-Hans.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.zh-Hans.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>刷新</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.zh-Hant.resx
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGenerator.zh-Hant.resx
@@ -177,4 +177,7 @@
   <data name="Refresh" xml:space="preserve">
     <value>重新整理</value>
   </data>
+  <data name="UuidObjectId" xml:space="preserve">
+    <value>ObjectId (MongoDB)</value>
+  </data>
 </root>

--- a/src/DevToys.Tools/Tools/Generators/UUID/UUIDGeneratorGuidTool.cs
+++ b/src/DevToys.Tools/Tools/Generators/UUID/UUIDGeneratorGuidTool.cs
@@ -126,7 +126,8 @@ internal sealed class UUIDGeneratorGuidTool : IGuiTool
                                             OnSettingChanged,
                                             Item(UUIDGenerator.UuidVersionOne, UuidVersion.One),
                                             Item(UUIDGenerator.UuidVersionFour, UuidVersion.Four),
-                                            Item(UUIDGenerator.UuidVersionSeven, UuidVersion.Seven)),
+                                            Item(UUIDGenerator.UuidVersionSeven, UuidVersion.Seven),
+                                            Item(UUIDGenerator.UuidObjectId, UuidVersion.ObjectId)),
 
                                     Setting()
                                         .Icon("FluentSystemIcons", '\uF57D')


### PR DESCRIPTION
Added a option to the UUID Generator to generate a MongoDB ObjectId

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

UUID-Generator has 3 types to generate.
1, 4 (GUID) and 7

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a new Entry to choose from called ObjectId (MongoDB)
- Added methods to generate the ObjectId based on the current MongoDB documentation
- Because of the ObjectId not using hyphens, the hyphen toggle is ignored
- Updated the localization files with the new string

## Other information

Image before:
![DevToys_E2kcm2q8BP](https://github.com/user-attachments/assets/f0c74977-f8b6-4f02-8cf9-1c506723d198)

Image after:
![DevToys_r8coIOgTh0](https://github.com/user-attachments/assets/5b6a02a5-5596-4baa-952a-d01572595769)

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- X ] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux