### PR TITLE
Cleaned Up Code Analysis Warnings for the Converters

### DIFF
--- a/src/DevToys.Tools.UnitTests/Tools/Converters/CronParserCommandLineToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/CronParserCommandLineToolTests.cs
@@ -27,7 +27,7 @@ public sealed class CronParserCommandLineToolTests : TestBase
     {
         _tool.CronExpression = input;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("");
@@ -42,7 +42,7 @@ public sealed class CronParserCommandLineToolTests : TestBase
         _tool.CronExpression = "* * * * *";
         _tool.DateFormat = input;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("");
@@ -58,7 +58,7 @@ public sealed class CronParserCommandLineToolTests : TestBase
         _tool.CronExpression = input;
         _tool.IncludeSeconds = includeSeconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().StartWith(expectedResult);

--- a/src/DevToys.Tools.UnitTests/Tools/Converters/CronParserGuiToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/CronParserGuiToolTests.cs
@@ -4,7 +4,7 @@ namespace DevToys.Tools.UnitTests.Tools.Converters;
 
 public sealed class CronParserGuiToolTests : TestBase
 {
-    private readonly ISettingsProvider _settingsProvider;
+    private readonly MockISettingsProvider _settingsProvider;
     private readonly UIToolView _toolView;
     private readonly CronParserGuiTool _tool;
     private readonly IUISingleLineTextInput _dateFormatText;
@@ -24,7 +24,7 @@ public sealed class CronParserGuiToolTests : TestBase
         _outputCronDescriptionText = (IUISingleLineTextInput)_toolView.GetChildElementById("cron-parser-output-description");
         _infoBar = (IUIInfoBar)_toolView.GetChildElementById("cron-parser-info-bar");
 
-        _settingsProvider.SetSetting(CronParserGuiTool.includeSeconds, true);
+        _settingsProvider.SetSetting(CronParserGuiTool.IncludeSecondsSetting, true);
     }
 
     [Theory(DisplayName = "Invalid cron expression")]
@@ -51,7 +51,7 @@ public sealed class CronParserGuiToolTests : TestBase
     [InlineData("* * * * *", false, "Every minute")]
     public void ParseCron(string input, bool includeSeconds, string expectedResult)
     {
-        _settingsProvider.SetSetting(CronParserGuiTool.includeSeconds, includeSeconds);
+        _settingsProvider.SetSetting(CronParserGuiTool.IncludeSecondsSetting, includeSeconds);
         _cronExpressionText.Text(input);
 
         _infoBar.IsOpened.Should().BeFalse();

--- a/src/DevToys.Tools.UnitTests/Tools/Converters/DateConverterCommandLineToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/DateConverterCommandLineToolTests.cs
@@ -30,7 +30,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.Input = input;
         _tool.FormatOption = DateFormat.Seconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
     }
 
@@ -54,7 +54,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Seconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -78,7 +78,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Seconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -108,7 +108,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Seconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -132,7 +132,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Seconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -162,7 +162,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Milliseconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -186,7 +186,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Milliseconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -216,7 +216,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Milliseconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -240,7 +240,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Milliseconds;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -266,7 +266,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Ticks;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 
@@ -290,7 +290,7 @@ public sealed class DateConverterCommandLineToolTests : TestBase
         _tool.TimeZoneOption = timeZoneString;
         _tool.FormatOption = DateFormat.Ticks;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
 

--- a/src/DevToys.Tools.UnitTests/Tools/Converters/DateConverterGuiToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/DateConverterGuiToolTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using DevToys.Tools.Models;
 using DevToys.Tools.Tools.Converters.Date;
 
@@ -102,6 +103,7 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData("1970-01-01T00:00:00.0000000-08:00", "Pacific Standard Time", 28800)]
     [InlineData("2023-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", 1700711887)]
     [InlineData("1900-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", -2180808113)]
+    [SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped")]
     public async Task ConvertValidDateTimeWithUnixEpochAndSecondsFormatShouldReturnValidTimestampInSeconds(
         string dateTimeString,
         string timeZoneString,
@@ -302,6 +304,7 @@ public class DateConverterGuiToolTests : TestBase
     [InlineData("1970-01-01T00:00:00.0000000-08:00", "Pacific Standard Time", 28800000)]
     [InlineData("2023-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", 1700711887000)]
     [InlineData("1900-11-22T19:58:07.0000000-08:00", "Pacific Standard Time", -2180808113000)]
+    [SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped")]
     public async Task ConvertValidDateTimeWithUnixEpochAndMillisecondsFormatShouldReturnValidTimestampInMilliseconds(
         string dateTimeString,
         string timeZoneString,

--- a/src/DevToys.Tools.UnitTests/Tools/Converters/JsonYamlConverterCommandLineToolTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Converters/JsonYamlConverterCommandLineToolTests.cs
@@ -16,8 +16,10 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
 
     public JsonYamlConverterCommandLineToolTests()
     {
-        _tool = new JsonYamlConverterCommandLineTool();
-        _tool._fileStorage = _fileStorage;
+        _tool = new JsonYamlConverterCommandLineTool
+        {
+            _fileStorage = _fileStorage
+        };
 
         _loggerMock = new Mock<ILogger>();
         Console.SetOut(_consoleWriter);
@@ -32,7 +34,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.ConversionMode = JsonToYamlConversion.JsonToYaml;
         _tool.Input = input;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
     }
 
@@ -44,7 +46,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.ConversionMode = JsonToYamlConversion.JsonToYaml;
         _tool.Input = "   bar { \"foo\": 123 }  ";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleErrorWriter.ToString().Trim();
         consoleOutput.Should().Be("'b' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 3.");
@@ -57,7 +59,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.IndentationMode = Indentation.TwoSpaces;
         _tool.Input = "{\r\n  \"foo\": \"bar\",\r\n  \"fizz\": [\r\n     \"wizz\"\r\n  ]\r\n}";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("foo: bar\r\nfizz:\r\n  - wizz".Replace("\r\n", Environment.NewLine));
@@ -70,7 +72,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.IndentationMode = Indentation.FourSpaces;
         _tool.Input = "{\r\n  \"foo\": \"bar\",\r\n  \"fizz\": [\r\n     \"wizz\"\r\n  ]\r\n}";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("foo: bar\r\nfizz:\r\n    - wizz".Replace("\r\n", Environment.NewLine));
@@ -86,7 +88,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.OutputFile = new FileInfo("Dummy.yaml");
         _fileStorage.FileExistsResult = false;
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleErrorWriter.ToString().Trim();
         consoleOutput.Should().Be(JsonYamlConverter.InputFileNotFound);
@@ -101,7 +103,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.Input = inputFile;
         _tool.OutputFile = new FileInfo("Dummy.yaml");
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleErrorWriter.ToString().Trim();
         consoleOutput.Should().Be("'b' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 3.");
@@ -116,7 +118,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.Input = inputFile;
         _tool.OutputFile = new FileInfo("TwoSpaces.yaml");
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string outputContent = File.ReadAllText(_tool.OutputFile.FullName);
         outputContent.Should().Be("foo: bar\r\nfizz:\r\n  - wizz\r\n".Replace("\r\n", Environment.NewLine));
@@ -132,7 +134,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.Input = inputFile;
         _tool.OutputFile = new FileInfo("FourSpaces.yaml");
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string outputContent = File.ReadAllText(_tool.OutputFile.FullName);
         outputContent.Should().Be("foo: bar\r\nfizz:\r\n    - wizz\r\n".Replace("\r\n", Environment.NewLine));
@@ -145,7 +147,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.IndentationMode = Indentation.TwoSpaces;
         _tool.Input = "{\"Name\": \"Dor\\u00e9\"}";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("Name: Dor\\u00e9".Replace("\r\n", Environment.NewLine));
@@ -158,7 +160,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.IndentationMode = Indentation.TwoSpaces;
         _tool.Input = "{\"Name\": \"doré\"}";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("Name: doré".Replace("\r\n", Environment.NewLine));
@@ -174,7 +176,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.ConversionMode = JsonToYamlConversion.YamlToJson;
         _tool.Input = "'L' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleErrorWriter.ToString().Trim();
         consoleOutput.Should().Be("While parsing a block mapping, did not find expected key.");
@@ -186,7 +188,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.ConversionMode = JsonToYamlConversion.YamlToJson;
         _tool.Input = "foo: bar\r\nfizz:\r\n - wizz";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("{\r\n  \"foo\": \"bar\",\r\n  \"fizz\": [\r\n    \"wizz\"\r\n  ]\r\n}".Replace("\r\n", Environment.NewLine));
@@ -199,7 +201,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.IndentationMode = Indentation.FourSpaces;
         _tool.Input = "foo: bar\r\nfizz:\r\n - wizz";
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be("{\r\n    \"foo\": \"bar\",\r\n    \"fizz\": [\r\n        \"wizz\"\r\n    ]\r\n}".Replace("\r\n", Environment.NewLine));
@@ -214,7 +216,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.Input = inputFile;
         _tool.OutputFile = new FileInfo("Dummy.json");
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(-1);
         string consoleOutput = _consoleErrorWriter.ToString().Trim();
         consoleOutput.Should().Be("While parsing a block mapping, did not find expected key.");
@@ -229,7 +231,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.Input = inputFile;
         _tool.OutputFile = new FileInfo("TwoSpaces.json");
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string outputContent = File.ReadAllText(_tool.OutputFile.FullName);
         outputContent.Should().Be("{\r\n  \"foo\": \"bar\",\r\n  \"fizz\": [\r\n    \"wizz\"\r\n  ]\r\n}".Replace("\r\n", Environment.NewLine));
@@ -245,7 +247,7 @@ public sealed class JsonYamlConverterCommandLineToolTests : TestBase
         _tool.Input = inputFile;
         _tool.OutputFile = new FileInfo("FourSpaces.json");
 
-        int result = await _tool.InvokeAsync(_loggerMock.Object, default);
+        int result = await _tool.InvokeAsync(_loggerMock.Object, TestContext.Current.CancellationToken);
         result.Should().Be(0);
         string outputContent = File.ReadAllText(_tool.OutputFile.FullName);
         outputContent.Should().Be("{\r\n    \"foo\": \"bar\",\r\n    \"fizz\": [\r\n        \"wizz\"\r\n    ]\r\n}".Replace("\r\n", Environment.NewLine));

--- a/src/DevToys.Tools/Tools/Converters/Cron/CronParserGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Cron/CronParserGuiTool.cs
@@ -23,7 +23,7 @@ internal sealed class CronParserGuiTool : IGuiTool
     /// <summary>
     /// Whether the tool should include seconds in Cron definition
     /// </summary>
-    internal static readonly SettingDefinition<bool> includeSeconds
+    private static readonly SettingDefinition<bool> includeSeconds
         = new(
             name: $"{nameof(CronParserGuiTool)}.{nameof(includeSeconds)}",
             defaultValue: true);
@@ -72,6 +72,8 @@ internal sealed class CronParserGuiTool : IGuiTool
 
         ParseCronExpression();
     }
+
+    internal static SettingDefinition<bool> IncludeSecondsSetting => includeSeconds;
 
     public UIToolView View
         => new(

--- a/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/Date/DateConverterGuiTool.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using DevToys.Tools.Helpers;
@@ -66,9 +66,13 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
             name: $"{nameof(DateConverterGuiTool)}.{nameof(formatSettings)}",
             defaultValue: DateFormat.Seconds);
 
-    private bool _ignoreInputTextChange;
+    [GeneratedRegex(@"[+-][0-9]{2}:[0-9]{2}|Z$")]
+    private static partial Regex TimezoneRegex();
 
-    private readonly ILogger _logger;
+    [GeneratedRegex(@"^\(UTC.*\).+$")]
+    private static partial Regex UTCRegex();
+
+    private bool _ignoreInputTextChange;
 
     private readonly DisposableSemaphore _semaphore = new();
 
@@ -138,7 +142,6 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
     [ImportingConstructor]
     public DateConverterGuiTool(ISettingsProvider settingsProvider)
     {
-        _logger = this.Log();
         _settingsProvider = settingsProvider;
 
         switch (_settingsProvider.GetSetting(useCustomEpochSettings))
@@ -448,8 +451,7 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
             return;
         }
 
-        var timeZoneRegex = new Regex(@"[+-][0-9]{2}:[0-9]{2}|Z$");
-        if (!timeZoneRegex.IsMatch(value))
+        if (!TimezoneRegex().IsMatch(value))
         {
             _errorInfoBar.Description(DateConverter.InvalidValue);
             _errorInfoBar.Open();
@@ -1050,7 +1052,7 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
         string timeZoneSelectedId = _settingsProvider.GetSetting(timeZoneIdSettings);
         var timeZoneDropDownItems = new IUIDropDownListItem[systemTimeZone.Count];
 
-        if (!Regex.IsMatch(systemTimeZone.ElementAt(0).DisplayName, @"^\(UTC.*\).+$"))
+        if (!UTCRegex().IsMatch(systemTimeZone.ElementAt(0).DisplayName))
         {
             // version < .Net6
             // This implementation mitigates the changes in the strings
@@ -1081,7 +1083,7 @@ internal sealed partial class DateConverterGuiTool : IGuiTool, IDisposable
                 }
             }
         }
-        return timeZoneDropDownItems.ToArray();
+        return [.. timeZoneDropDownItems];
     }
 
     private void ComputeDstInformation(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZone)

--- a/src/DevToys.Tools/Tools/Converters/JsonTable/JsonTableConverterCommandLineTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/JsonTable/JsonTableConverterCommandLineTool.cs
@@ -1,9 +1,10 @@
 ﻿using DevToys.Tools.Helpers;
 using DevToys.Tools.Tools.Converters.JsonTable;
+using DevToys.Tools.Tools.Converters.JsonYaml;
 using Microsoft.Extensions.Logging;
 using OneOf;
 
-namespace DevToys.Tools.Tools.Converters.JsonYaml;
+namespace DevToys.Tools.Tools.Converters.JsonTable;
 
 [Export(typeof(ICommandLineTool))]
 [Name("JsonTableConverter")]

--- a/src/DevToys.Tools/Tools/Converters/JsonTable/JsonTableConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/JsonTable/JsonTableConverterGuiTool.cs
@@ -1,9 +1,10 @@
 ﻿using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using DevToys.Tools.Tools.Converters.JsonTable;
 using Microsoft.Extensions.Logging;
 using static DevToys.Tools.Helpers.JsonTableHelper;
 
-namespace DevToys.Tools.Tools.Converters.JsonYaml;
+namespace DevToys.Tools.Tools.Converters.JsonTable;
 
 [Export(typeof(IGuiTool))]
 [Name("JsonTableConverter")]
@@ -21,7 +22,6 @@ namespace DevToys.Tools.Tools.Converters.JsonYaml;
 [AcceptedDataTypeName(PredefinedCommonDataTypeNames.JsonArray)]
 internal sealed partial class JsonTableConverterGuiTool : IGuiTool, IDisposable
 {
-    private readonly ILogger _logger;
     private readonly IClipboard _clipboard;
     private readonly IFileStorage _fileStorage;
 
@@ -33,9 +33,9 @@ internal sealed partial class JsonTableConverterGuiTool : IGuiTool, IDisposable
     private CancellationTokenSource? _cancellationTokenSource;
 
     [ImportingConstructor]
+    [SuppressMessage("Style", "IDE0290:Use primary constructor", Justification = "Primary constructors are not compatible with MEF's [ImportingConstructor] attribute.")]
     public JsonTableConverterGuiTool(IClipboard clipboard, IFileStorage fileStorage)
     {
-        _logger = this.Log();
         _clipboard = clipboard;
         _fileStorage = fileStorage;
     }
@@ -167,7 +167,7 @@ internal sealed partial class JsonTableConverterGuiTool : IGuiTool, IDisposable
 
     private void SetDataGridData(DataGridContents table)
     {
-        IUIDataGridRow[] rows = table.Rows.Select(r => Row(null, r)).ToArray();
+        IUIDataGridRow[] rows = [.. table.Rows.Select(r => Row(null, r))];
         _outputDataGrid.WithColumns(table.Headings);
         _outputDataGrid.WithRows(rows);
     }

--- a/src/DevToys.Tools/Tools/Converters/NumberBase/NumberBaseConverterGuiTool.cs
+++ b/src/DevToys.Tools/Tools/Converters/NumberBase/NumberBaseConverterGuiTool.cs
@@ -20,7 +20,7 @@ internal sealed class NumberBaseConverterGuiTool : IGuiTool
     /// <summary>
     /// Whether the value should be formatted or not.
     /// </summary>
-    internal static readonly SettingDefinition<bool> formatted
+    private static readonly SettingDefinition<bool> formatted
         = new(
             name: $"{nameof(NumberBaseConverterGuiTool)}.{nameof(formatted)}",
             defaultValue: true);
@@ -33,8 +33,6 @@ internal sealed class NumberBaseConverterGuiTool : IGuiTool
             name: $"{nameof(NumberBaseConverterGuiTool)}.{nameof(advancedMode)}",
             defaultValue: false);
 
-    private readonly DisposableSemaphore _semaphore = new();
-    private readonly ILogger _logger;
     private readonly ISettingsProvider _settingsProvider;
     private readonly IUIStack _modeContainer = Stack();
     private readonly IUIInfoBar _infoBar = InfoBar();
@@ -46,7 +44,6 @@ internal sealed class NumberBaseConverterGuiTool : IGuiTool
     [ImportingConstructor]
     public NumberBaseConverterGuiTool(ISettingsProvider settingsProvider)
     {
-        _logger = this.Log();
         _settingsProvider = settingsProvider;
 
         _basicMode = new(() => new NumberBaseConverterGuiToolBasicMode(_settingsProvider, OnError));
@@ -54,6 +51,9 @@ internal sealed class NumberBaseConverterGuiTool : IGuiTool
 
         ApplyMode();
     }
+
+    public static SettingDefinition<bool> FormattedSetting => formatted;
+    public static SettingDefinition<bool> AdvancedModeSetting => advancedMode;
 
     public UIToolView View
         => new(

--- a/src/DevToys.Tools/Tools/Converters/NumberBase/NumberBaseConverterGuiToolAdvancedMode.cs
+++ b/src/DevToys.Tools/Tools/Converters/NumberBase/NumberBaseConverterGuiToolAdvancedMode.cs
@@ -130,7 +130,7 @@ internal sealed class NumberBaseConverterGuiToolAdvancedMode : INumberBaseConver
         }
 
         // Convert the number.
-        bool format = _settingsProvider.GetSetting(NumberBaseConverterGuiTool.formatted);
+        bool format = _settingsProvider.GetSetting(NumberBaseConverterGuiTool.FormattedSetting);
         bool succeeded
             = NumberBaseHelper.TryConvertNumberBase(
                 _inputText.Text,

--- a/src/DevToys.Tools/Tools/Converters/NumberBase/NumberBaseConverterGuiToolBasicMode.cs
+++ b/src/DevToys.Tools/Tools/Converters/NumberBase/NumberBaseConverterGuiToolBasicMode.cs
@@ -81,7 +81,7 @@ internal sealed class NumberBaseConverterGuiToolBasicMode : INumberBaseConverter
 
         Guard.IsNotNull(_inputValue);
 
-        bool format = _settingsProvider.GetSetting(NumberBaseConverterGuiTool.formatted);
+        bool format = _settingsProvider.GetSetting(NumberBaseConverterGuiTool.FormattedSetting);
 
         bool succeeded
             = NumberBaseHelper.TryConvertNumberBase(


### PR DESCRIPTION
Cleaned up code analysis warnings for the Converters and their unit tests.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

The Converter tools and their unit tests had multiple code analysis warnings:

- Unit tests used default cancellation token instead of proper test context tokens
- Settings constants used camelCase naming instead of PascalCase convention
- Test classes used generic `ISettingsProvider` interface instead of the more specific `MockISettingsProvider` type

## What is the new behavior?

| Code | File | Explanation | Remediation |
|------|------|-------------|-------------|
| SYSLIB1045 | DateConverterGuiTool.cs:451 | Regex pattern should use source-generated regex for better performance | Replaced `new Regex(@"[+-][0-9]{2}:[0-9]{2}` with a GeneratedRegex |
| SYSLIB1045 | DateConverterGuiTool.cs:1053 | Regex pattern should use source-generated regex for better performance | Replaced Regex.IsMatch(..., @"^\(UTC.*\).+$") with a GeneratedRegex |
| xUnit1004 | DateConverterGuiToolTests.cs:98 | Test method has Skip attribute or appears to be skipped | Added [SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped")] to suppress the warning |
| xUnit1004 | DateConverterGuiToolTests.cs:298 | Test method has Skip attribute or appears to be skipped | Added [SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped")] to suppress the warning |
| IDE0052 | NumberBaseConverterGuiTool.cs:36 | Private member _semaphore is declared but never used | Removed unused field private readonly DisposableSemaphore _semaphore = new(); |
| IDE0052 | NumberBaseConverterGuiTool.cs:37 | Private member _logger is declared but never used | Removed unused field private readonly ILogger _logger; and its initialization _logger = this.Log(); |
| IDE0052 | JsonTableConverterGuiTool.cs:24 | Private member _logger is declared but never used | Removed unused field private readonly ILogger _logger; and its initialization _logger = this.Log(); |
| IDE0052 | DateConverterGuiTool.cs:71 | Private member _logger is declared but never used | Removed unused field private readonly ILogger _logger; and its initialization in constructor |
| IDE0017 | JsonYamlConverterCommandLineToolTests.cs:19 | Object initialization can be simplified | Changed from separate instantiation and property assignment to collection initializer syntax: new() { _fileStorage = _fileStorage } |
| IDE1006 | CronParserGuiTool.cs:26 | Naming rule violation: field should use PascalCase | Changed includeSeconds from internal static readonly to private static readonly and added public property IncludeSecondsSetting |
| IDE1006 | NumberBaseConverterGuiTool.cs:23 | Naming rule violation: field should use PascalCase | Changed formatted and advancedMode from internal static readonly to private static readonly and added public properties FormattedSetting and AdvancedModeSetting |
| IDE0130 | JsonTableConverterCommandLineTool.cs:6 | Namespace does not match folder structure | Changed namespace from DevToys.Tools.Tools.Converters.JsonYaml to DevToys.Tools.Tools.Converters.JsonTable |
| IDE0130 | JsonTableConverterGuiTool.cs:6 | Namespace does not match folder structure | Changed namespace from DevToys.Tools.Tools.Converters.JsonYaml to DevToys.Tools.Tools.Converters.JsonTable |
| IDE0305 | DateConverterGuiTool.cs:1084 | Collection expression can be simplified | Changed timeZoneDropDownItems.ToArray() to collection expression [.. timeZoneDropDownItems] |
| IDE0305 | JsonTableConverterGuiTool.cs:170 | Collection expression can be simplified | Changed .ToArray() to collection expression [.. table.Rows.Select(r => Row(null, r))] |
| CA1859 | CronParserGuiToolTests.cs:7 | Use concrete types when possible for improved performance | Changed field type from ISettingsProvider to MockISettingsProvider |
| xUnit1051 | CronParserCommandLineToolTests.cs:30 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | CronParserCommandLineToolTests.cs:45 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | CronParserCommandLineToolTests.cs:61 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:33 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:57 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:81 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:111 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:135 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:165 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:189 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:219 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:243 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:269 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | DateConverterCommandLineToolTests.cs:293 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:35 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:47 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:60 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:73 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:89 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:104 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:119 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:135 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:148 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:161 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:177 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:189 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:202 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:217 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:232 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |
| xUnit1051 | JsonYamlConverterCommandLineToolTests.cs:248 | Do not use blocking task operations in test methods; use default for CancellationToken | Replaced default with TestContext.Current.CancellationToken |

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux