### PR TITLE
Show a warning when excluded characters remove all available password characters

### DIFF
--- a/src/DevToys.Tools.UnitTests/Tools/Helpers/PasswordGeneratorHelperTests.cs
+++ b/src/DevToys.Tools.UnitTests/Tools/Helpers/PasswordGeneratorHelperTests.cs
@@ -12,6 +12,8 @@ public class PasswordGeneratorHelperTests
     [InlineData(500, true, true, true, true, null)]
     [InlineData(500, true, true, true, true, "bcdefghijklmnopqrstuvwxyz")]
     [InlineData(500, false, true, false, false, "bcdefghijklmnopqrstuvwxyz")]
+    [InlineData(500, true, true, true, true, "@, :, /, %, &, ?, #, +, !, $, ^, *")] // https://github.com/DevToys-app/DevToys/issues/1663
+    [InlineData(500, true, true, true, true, "^, *")] // https://github.com/DevToys-app/DevToys/issues/1663
     internal void GeneratePassword(int length, bool hasUppercase, bool hasLowercase, bool hasNumber, bool hasSpecialCharacters, string excludedCharacters)
     {
         string password
@@ -64,6 +66,56 @@ public class PasswordGeneratorHelperTests
 
         if (excludedCharacters != null)
             NotContainAny(password, excludedCharacters);
+    }
+
+    [Fact]
+    internal void GeneratePasswordWithAllCharactersExcludedReturnsEmpty()
+    {
+        const string allCharacters
+            = PasswordGeneratorHelper.UppercaseLetters
+            + PasswordGeneratorHelper.LowercaseLetters
+            + PasswordGeneratorHelper.Digits
+            + PasswordGeneratorHelper.NonAlphanumeric;
+
+        string password
+            = PasswordGeneratorHelper.GeneratePassword(
+                36,
+                hasUppercase: true,
+                hasLowercase: true,
+                hasNumbers: true,
+                hasSpecialCharacters: true,
+                allCharacters.ToCharArray());
+
+        password.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(true, true, true, true, null, true)]
+    [InlineData(true, true, true, true, "@, :, /, %, &, ?, #, +, !, $, ^, *", true)]
+    [InlineData(true, true, true, true, "^, *", true)]
+    [InlineData(false, false, false, true, PasswordGeneratorHelper.NonAlphanumeric, false)]
+    [InlineData(false, true, false, false, PasswordGeneratorHelper.LowercaseLetters, false)]
+    [InlineData(
+        true,
+        true,
+        true,
+        true,
+        PasswordGeneratorHelper.UppercaseLetters
+            + PasswordGeneratorHelper.LowercaseLetters
+            + PasswordGeneratorHelper.Digits
+            + PasswordGeneratorHelper.NonAlphanumeric,
+        false)]
+    internal void HasAnyCharacterAvailable(bool hasUppercase, bool hasLowercase, bool hasNumbers, bool hasSpecialCharacters, string excludedCharacters, bool expectedResult)
+    {
+        bool result
+            = PasswordGeneratorHelper.HasAnyCharacterAvailable(
+                hasUppercase,
+                hasLowercase,
+                hasNumbers,
+                hasSpecialCharacters,
+                excludedCharacters?.ToCharArray());
+
+        result.Should().Be(expectedResult);
     }
 
     private static void ContainAny(string password, string characters)

--- a/src/DevToys.Tools/Helpers/PasswordGeneratorHelper.cs
+++ b/src/DevToys.Tools/Helpers/PasswordGeneratorHelper.cs
@@ -43,34 +43,11 @@ internal static class PasswordGeneratorHelper
             return string.Empty;
         }
 
-        // Combine all character sets together.
-        var randomCharsBuilder = new StringBuilder();
-        string randomChars;
-
         var rand = new CryptoRandom();
         var newPasswordCharacters = new List<char>();
 
-        if (hasUppercase)
-        {
-            randomCharsBuilder.Append(RemoveExcludedCharacters(UppercaseLetters, excludedCharacters));
-        }
-
-        if (hasLowercase)
-        {
-            randomCharsBuilder.Append(RemoveExcludedCharacters(LowercaseLetters, excludedCharacters));
-        }
-
-        if (hasNumbers)
-        {
-            randomCharsBuilder.Append(RemoveExcludedCharacters(Digits, excludedCharacters));
-        }
-
-        if (hasSpecialCharacters)
-        {
-            randomCharsBuilder.Append(RemoveExcludedCharacters(NonAlphanumeric, excludedCharacters));
-        }
-
-        randomChars = randomCharsBuilder.ToString();
+        // Combine all character sets together.
+        string randomChars = CombineCharacterSets(hasUppercase, hasLowercase, hasNumbers, hasSpecialCharacters, excludedCharacters);
 
         // Only continue if the user hasn't excluded everything.
         if (randomChars.Length != 0)
@@ -82,6 +59,52 @@ internal static class PasswordGeneratorHelper
         }
 
         return new string(newPasswordCharacters.ToArray());
+    }
+
+    /// <summary>
+    /// Indicates whether at least one character remains available to generate a password with,
+    /// once the excluded characters are removed from the enabled character sets.
+    /// </summary>
+    internal static bool HasAnyCharacterAvailable(
+        bool hasUppercase,
+        bool hasLowercase,
+        bool hasNumbers,
+        bool hasSpecialCharacters,
+        char[]? excludedCharacters)
+    {
+        return CombineCharacterSets(hasUppercase, hasLowercase, hasNumbers, hasSpecialCharacters, excludedCharacters).Length > 0;
+    }
+
+    private static string CombineCharacterSets(
+        bool hasUppercase,
+        bool hasLowercase,
+        bool hasNumbers,
+        bool hasSpecialCharacters,
+        char[]? excludedCharacters)
+    {
+        var combinedCharsBuilder = new StringBuilder();
+
+        if (hasUppercase)
+        {
+            combinedCharsBuilder.Append(RemoveExcludedCharacters(UppercaseLetters, excludedCharacters));
+        }
+
+        if (hasLowercase)
+        {
+            combinedCharsBuilder.Append(RemoveExcludedCharacters(LowercaseLetters, excludedCharacters));
+        }
+
+        if (hasNumbers)
+        {
+            combinedCharsBuilder.Append(RemoveExcludedCharacters(Digits, excludedCharacters));
+        }
+
+        if (hasSpecialCharacters)
+        {
+            combinedCharsBuilder.Append(RemoveExcludedCharacters(NonAlphanumeric, excludedCharacters));
+        }
+
+        return combinedCharsBuilder.ToString();
     }
 
     private static string RemoveExcludedCharacters(string input, char[]? excludedCharacters)

--- a/src/DevToys.Tools/Tools/Generators/Password/PasswordGenerator.Designer.cs
+++ b/src/DevToys.Tools/Tools/Generators/Password/PasswordGenerator.Designer.cs
@@ -70,6 +70,15 @@ namespace DevToys.Tools.Tools.Generators.Password {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No password(s) can be generated because all the available characters have been excluded..
+        /// </summary>
+        internal static string AllCharactersExcludedWarning {
+            get {
+                return ResourceManager.GetString("AllCharactersExcludedWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configuration.
         /// </summary>
         internal static string ConfigurationTitle {

--- a/src/DevToys.Tools/Tools/Generators/Password/PasswordGenerator.resx
+++ b/src/DevToys.Tools/Tools/Generators/Password/PasswordGenerator.resx
@@ -120,6 +120,9 @@
   <data name="AccessibleName" xml:space="preserve">
     <value>Password Generator tool</value>
   </data>
+  <data name="AllCharactersExcludedWarning" xml:space="preserve">
+    <value>No password(s) can be generated because all the available characters have been excluded.</value>
+  </data>
   <data name="ConfigurationTitle" xml:space="preserve">
     <value>Configuration</value>
   </data>

--- a/src/DevToys.Tools/Tools/Generators/Password/PasswordGeneratorCommandLineTool.cs
+++ b/src/DevToys.Tools/Tools/Generators/Password/PasswordGeneratorCommandLineTool.cs
@@ -50,6 +50,17 @@ internal sealed class PasswordGeneratorCommandLineTool : ICommandLineTool
 
     public ValueTask<int> InvokeAsync(ILogger logger, CancellationToken cancellationToken)
     {
+        if (!PasswordGeneratorHelper.HasAnyCharacterAvailable(
+                Uppercase,
+                Lowercase,
+                Digits,
+                SpecialCharacters,
+                ExcludedCharacters.ToArray()))
+        {
+            Console.Error.WriteLine(PasswordGenerator.AllCharactersExcludedWarning);
+            return ValueTask.FromResult(-1);
+        }
+
         string password
             = PasswordGeneratorHelper.GeneratePassword(
                 Length,

--- a/src/DevToys.Tools/Tools/Generators/Password/PasswordGeneratorGuidTool.cs
+++ b/src/DevToys.Tools/Tools/Generators/Password/PasswordGeneratorGuidTool.cs
@@ -256,13 +256,10 @@ internal sealed class PasswordGeneratorGuidTool : IGuiTool
         // There are no character sets selected, so we can't generate anything.
         if (!HasAnyCharacterSets)
         {
+            _infoBar.Description(PasswordGenerator.NoCharacterSetsWarning);
             _infoBar.Open();
             _outputText.Text(string.Empty);
             return;
-        }
-        else
-        {
-            _infoBar.Close();
         }
 
         bool hasUppercase = _settingsProvider.GetSetting(uppercase);
@@ -271,6 +268,17 @@ internal sealed class PasswordGeneratorGuidTool : IGuiTool
         bool hasSpecialCharacters = _settingsProvider.GetSetting(specialCharacters);
         char[] excludedCharactersList = _settingsProvider.GetSetting(excludedCharacters).ToCharArray();
         int passwordLength = _settingsProvider.GetSetting(length);
+
+        // The excluded characters cover every character of the selected sets, so we can't generate anything.
+        if (!PasswordGeneratorHelper.HasAnyCharacterAvailable(hasUppercase, hasLowercase, hasNumbers, hasSpecialCharacters, excludedCharactersList))
+        {
+            _infoBar.Description(PasswordGenerator.AllCharactersExcludedWarning);
+            _infoBar.Open();
+            _outputText.Text(string.Empty);
+            return;
+        }
+
+        _infoBar.Close();
 
         // Generate a random password using the the combined character set.
         var newPasswords = new StringBuilder();


### PR DESCRIPTION
Related to DevToys-app/DevToys#1663.

The crash and asterisk-only output reported in that issue are specific to the DevToys v1 codebase (regex-based exclusion in `PasswordGeneratorToolViewModel`); details in [this comment](https://github.com/DevToys-app/DevToys/issues/1663#issuecomment-5453099615). The 2.0 implementation is unaffected, but it silently outputs nothing when the excluded characters cover every character of the enabled sets, where the issue's expected behavior asks for a validation message.

### What changed

- `PasswordGeneratorHelper`: new `HasAnyCharacterAvailable(...)`, sharing the character-pool construction with `GeneratePassword` (extracted `CombineCharacterSets`; no behavior change to generation).
- GUI tool: when the exclusion list removes all available characters, the existing info bar opens with a new `AllCharactersExcludedWarning` message instead of showing an empty output. The info bar description is now set per warning so the two messages don't overwrite each other.
- CLI tool: same condition writes the warning to stderr and returns -1, consistent with the other command-line tools.
- New `AllCharactersExcludedWarning` string added to the neutral `PasswordGenerator.resx` only (localized files left to Crowdin).

### Tests

- Regression cases for both exclusion strings from the issue report.
- Theory covering `HasAnyCharacterAvailable`, including partially and fully excluded sets.
- Fact asserting that excluding every character returns an empty password without throwing.

Full suite: 940 passed, 0 failed.
